### PR TITLE
fix: when content was more than view-height you couldn't see content

### DIFF
--- a/client/src/components/Container/container.module.css
+++ b/client/src/components/Container/container.module.css
@@ -1,5 +1,5 @@
 .container {
-  height: 100vh;
+  min-height: 100vh;
   padding: 0 25px;
   overflow-x: hidden;
 }

--- a/client/src/routes/Home/home.module.css
+++ b/client/src/routes/Home/home.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100vh;
 }
 .header {
   padding: 25px 0 10px 0;

--- a/client/src/routes/Menu/menu.module.css
+++ b/client/src/routes/Menu/menu.module.css
@@ -8,7 +8,7 @@
   justify-content: center;
   align-self: flex-end;
   width: 100%;
-  height: 100%;
+  min-height: 100vh;
 }
 
 .navigationContainer {


### PR DESCRIPTION
## Describe your changes
I changed container component height from 100vh to min-height 100vh, because for example when your component which is using height: 100vh is 500px but content is 600px, you dont see 100px. In case with min height, basically your component is 500px but if there is more content it grows.

 Probably I missunderstood the problem and that is not how it actually works, you can check it if you go to landing page and choose in dimensions Samsung Galaxy S20 ultra, everything seems fine and you see title and image, but if your click rotate button, you dont see title anymore and you can't scroll to it, but my pull request fixes it.
 
  Because it requires change of global container component it changed all pages, I fixed some of then, but I could miss something
## Issue ticket number and link
#55 
## Name of Contributor
Dmitry
## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My code does not generate any new warnings or errors
- [X] New and existing unit tests pass locally with my changes (if relevant)
